### PR TITLE
Webフォントのスタイルシート指定箇所を変更

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -92,11 +92,6 @@ if (!import.meta.dev && runtimeConfig.public.cfWebAnalyticsToken) {
 const appConfig = useAppConfig();
 
 useServerHead({
-  link: [
-    { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-    { rel: 'preconnect', href: 'https://fonts.gstatic.com' },
-    { href: 'https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;700&display=swap', rel: 'stylesheet' },
-  ],
   htmlAttrs: {
     lang: 'ja-JP',
   },

--- a/components/ArticleRenderer.vue
+++ b/components/ArticleRenderer.vue
@@ -35,13 +35,11 @@ defineProps<{
 
 .renderer>h2 {
   font-size: 1.3rem;
-  font-weight: 500;
   border-block-end: solid 0.3rem var(--split);
 }
 
 .renderer>h3 {
   font-size: 1.1rem;
-  font-weight: 500;
 }
 
 .renderer>h1:first-child {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,13 @@ export default defineNuxtConfig({
       name: 'page',
       mode: 'out-in',
     },
+    head: {
+      link: [
+        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        { rel: 'preconnect', href: 'https://fonts.gstatic.com' },
+        { href: 'https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;700&display=swap', rel: 'stylesheet' },
+      ],
+    },
   },
   nitro: {
     prerender: {


### PR DESCRIPTION
- Webフォントのスタイルシート指定箇所を変更
  - app.vue内のuseServerHeadから、nuxt.config.tsのapp.headへ
- 記事の見出しのfont-weightを指定しないように