### PR TITLE
categoryが指定されていない投稿をカテゴリ未設定として扱うように

### DIFF
--- a/components/ArticleListItem.vue
+++ b/components/ArticleListItem.vue
@@ -13,9 +13,9 @@
       <div :class="$style.categoryContainer">
         <IconFolder size="1rem"
                     aria-hidden="true" />
-        <NuxtLink :to="item.category !== undefined ? `/category/${item.category}` : undefined"
-                  :class="[$style.category, { [$style.noCategory]: item.category === undefined }]">
-          {{ item.category !== undefined ? item.category : '未設定' }}
+        <NuxtLink :to="`/category/${item.category}`"
+                  :class="$style.category">
+          {{ item.category !== undefined && item.category !== 'undefined' ? item.category : '未設定' }}
         </NuxtLink>
       </div>
       <div :class="$style.dateContainer">
@@ -122,19 +122,15 @@ defineProps<{
   transition: color var(--hoverTransitionDuration) var(--hoverTransitionFunction);
 }
 
-.noCategory {
-  cursor: default;
-}
-
 @media (hover: hover) {
-  .category:not(.noCategory):hover {
+  .category:hover {
     text-decoration: underline;
     color: var(--fg);
   }
 }
 
 @media (hover: none) {
-  .category:not(.noCategory):active {
+  .category:active {
     text-decoration: underline;
     color: var(--fg);
   }

--- a/pages/category/[name].vue
+++ b/pages/category/[name].vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="category"
          :class="$style.categoryName">
-      カテゴリ「{{ category }}」の投稿
+      カテゴリ「{{ category !== undefined && category !== 'undefined' ? category : '未設定' }}」の投稿
     </div>
     <div v-else
          :class="$style.categoryName">
@@ -34,8 +34,13 @@ const { data: articleCount } = await useAsyncData(
   () => {
     const query = queryContent('posts');
 
-    if (category.value !== undefined) {
+    if (category.value !== 'undefined') {
       query.where({ category: category.value });
+    }
+    else {
+      query.where({
+        $or: [{ category: { $exists: false } }, { category: 'undefined' }],
+      });
     }
 
     return query.count();
@@ -87,8 +92,13 @@ const { data: articles } = await useAsyncData(
   () => {
     const query = queryContent('posts');
 
-    if (category.value !== undefined) {
+    if (category.value !== 'undefined') {
       query.where({ category: category.value });
+    }
+    else {
+      query.where({
+        $or: [{ category: { $exists: false } }, { category: 'undefined' }],
+      });
     }
 
     return query

--- a/pages/category/index.vue
+++ b/pages/category/index.vue
@@ -9,7 +9,7 @@
             :key="item[0]"
             :class="$style.categoryListItem">
           <NuxtLink :to="`/category/${item[0]}`">
-            {{ `${item[0]} (${item[1]})` }}
+            {{ `${item[0] !== 'undefined' ? item[0] : '未設定'} (${item[1]})` }}
           </NuxtLink>
         </li>
       </ul>
@@ -28,9 +28,7 @@ const categoryList = computed(() => {
   const map = new Map<string | undefined, number>();
 
   data.value.forEach((content) => {
-    if (content.category !== undefined) {
-      map.set(content.category, (map.get(content.category) ?? 0) + 1);
-    }
+    map.set(content.category ?? 'undefined', (map.get(content.category ?? 'undefined') ?? 0) + 1);
   });
 
   return Array.from(map).sort((a, b) => b[1] - a[1]);


### PR DESCRIPTION
- categoryが指定されていない投稿を、カテゴリ未設定として扱うように
- categoryに"undefined"という文字列が指定されている投稿と、categoryが指定されていない投稿は、同じカテゴリとして扱うように